### PR TITLE
fix: script error handling and reliable version extraction

### DIFF
--- a/scripts/publish-sdk
+++ b/scripts/publish-sdk
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 pkg_name="@poap-xyz/poap-sdk"
 
 echo "Package $pkg_name.."
 
 local_version=$(jq -r '.version' package.json)
-remote_version=$(pnpm info "$pkg_name" --fields version --json 2>/dev/null | jq -r '.version')
+remote_version=$(pnpm info "$pkg_name" version --json 2>/dev/null | jq -r '.[0] // .')
 
 echo
 echo "Building package $pkg_name@$local_version.."


### PR DESCRIPTION
## Description

noticed the script could silently continue on failures or unset variables, which could cause incorrect results.

* added `set -euo pipefail` so the script exits immediately on errors and avoids using empty vars.
* updated `remote_version` extraction with:

```bash
remote_version=$(pnpm info "$pkg_name" version --json 2>/dev/null | jq -r '.[0] // .')
```

this handles both array and string outputs from `pnpm`, making the version parsing consistent and reliable.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have updated the documentation accordingly.
