### PR TITLE
chore: Add typescript buildinfo file to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ coverage
 .idea
 .vscode
 
+# Ignore Typescript build info files
+tsconfig.tsbuildinfo
+
 # Ignore Typescript definitions file extension
 *.d.ts


### PR DESCRIPTION
The file is generate when compiling to check types with `pnpm tsc`