### PR TITLE
Authentication provider refactor

### DIFF
--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.18.0
+
+{<h3>Breaking Changes ⚠️</h3>}
+
+* **[Providers]** `AuthenticationProvider.getJWT` has been changed for `getAuthToken` that returns an object with the whole OAuth token information. It is now cached by audience so many clients could share the same provider.
+
 ## 0.17.0
 
 {<h3>Features</h3>}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poap-sdk",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "SDK for everything POAP",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/moments/client/MomentsClientFactory/MomentsClientFactory.ts
+++ b/src/moments/client/MomentsClientFactory/MomentsClientFactory.ts
@@ -8,8 +8,6 @@ import { MomentsClient } from '../MomentsClient';
 import { GetMomentsDefaultClientOptions } from './options/GetMomentsDefaultClientOptions';
 
 export class MomentsClientFactory {
-  private static readonly DEFAULT_OAUTH_SERVER = 'https://accounts.poap.tech';
-
   public static getMomentsDefaultClient(
     params: GetMomentsDefaultClientOptions,
   ): MomentsClient {
@@ -45,8 +43,7 @@ export class MomentsClientFactory {
     return new AuthenticationProviderHttp(
       params.moments.oAuthCredentials.clientId,
       params.moments.oAuthCredentials.clientSecret,
-      params.moments.oAuthCredentials.oAuthServerDomain ??
-        MomentsClientFactory.DEFAULT_OAUTH_SERVER,
+      params.moments.oAuthCredentials.oAuthServerDomain,
     );
   }
 }

--- a/src/moments/client/MomentsClientFactory/options/GetMomentsDefaultClientOptions.ts
+++ b/src/moments/client/MomentsClientFactory/options/GetMomentsDefaultClientOptions.ts
@@ -30,7 +30,7 @@ export interface MomentsWithOAuthCredentials extends MomentsBaseOptions {
     clientSecret: string;
     /**
      * The domain of the OAuth server.
-     * @default https://accounts.poap.tech
+     * @default auth.accounts.poap.xyz
      */
     oAuthServerDomain?: string;
   };

--- a/src/providers/core/PoapMomentsApi/PoapMomentsApi.ts
+++ b/src/providers/core/PoapMomentsApi/PoapMomentsApi.ts
@@ -159,6 +159,10 @@ export class PoapMomentsApi implements MomentsApiProvider {
       );
     }
 
-    return `Bearer ${await this.authenticationProvider.getJWT(this.baseUrl)}`;
+    const authToken = await this.authenticationProvider.getAuthToken(
+      this.baseUrl,
+    );
+
+    return `Bearer ${authToken.accessToken}`;
   }
 }

--- a/src/providers/core/PoapTokenApi/PoapTokenApi.ts
+++ b/src/providers/core/PoapTokenApi/PoapTokenApi.ts
@@ -146,7 +146,12 @@ export class PoapTokenApi implements TokensApiProvider {
     if (!this.authenticationProvider) {
       throw new MissingAuthenticationProviderError();
     }
-    return `Bearer ${await this.authenticationProvider.getJWT(this.baseUrl)}`;
+
+    const authToken = await this.authenticationProvider.getAuthToken(
+      this.baseUrl,
+    );
+
+    return `Bearer ${authToken.accessToken}`;
   }
 }
 

--- a/src/providers/ports/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/providers/ports/AuthenticationProvider/AuthenticationProvider.ts
@@ -1,3 +1,5 @@
+import { AuthToken } from './types/AuthToken';
+
 /**
  * Authentication provider port
  *
@@ -8,5 +10,5 @@ export interface AuthenticationProvider {
    * Get a JWT from the authentication provider
    * @param audience The audience of the JWT
    */
-  getJWT(audience: string): Promise<string>;
+  getAuthToken(audience: string): Promise<AuthToken>;
 }

--- a/src/providers/ports/AuthenticationProvider/index.ts
+++ b/src/providers/ports/AuthenticationProvider/index.ts
@@ -1,2 +1,3 @@
 export * from './AuthenticationProvider';
 export * from './errors';
+export * from './types';

--- a/src/providers/ports/AuthenticationProvider/types/AuthToken.ts
+++ b/src/providers/ports/AuthenticationProvider/types/AuthToken.ts
@@ -1,0 +1,10 @@
+/**
+ * @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+ */
+export interface AuthToken {
+  accessToken: string;
+  tokenType: string;
+  expiresAt?: Date;
+  refreshToken?: string;
+  scope?: string;
+}

--- a/src/providers/ports/AuthenticationProvider/types/index.ts
+++ b/src/providers/ports/AuthenticationProvider/types/index.ts
@@ -1,0 +1,1 @@
+export * from './AuthToken';


### PR DESCRIPTION
## Description

The authentication provider has been refactor to return the whole authentication token instead of just the access token.

A bug that appear when the provider was shared by many clients has been fixed as it now caches it by audience.

Also a bug in `MomentsClientFactory.ts` has been fixed where it tried to fetch `https://https://accounts.poap.tech` and failed. Is this even used? We could remove it if not.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [x] I have updated the documentation accordingly.
